### PR TITLE
clock_gettime require -lrt to link

### DIFF
--- a/test/latency/liquibook_latency.mpc
+++ b/test/latency/liquibook_latency.mpc
@@ -1,3 +1,4 @@
 project (lt_order_book) : liquibook_book, liquibook_impl, liquibook_test {
   exename = *
+  libs += rt
 }


### PR DESCRIPTION
latency test use posix API: clock_gettime() in `rt'