### PR TITLE
Changed ! price_ == rhs to !( price_ == rhs ).

### DIFF
--- a/src/book/comparable_price.h
+++ b/src/book/comparable_price.h
@@ -86,7 +86,7 @@ public:
   /// @brief inequality compare key to a price
   bool operator !=(Price rhs) const
   {
-    return ! price_ == rhs;
+    return !( price_ == rhs );
   }
 
   /// @brief greater than compare key to a price


### PR DESCRIPTION
Logical not is only applied to the left hand side of this comparison.