### PR TITLE
Changes to make tests and examples compile

### DIFF
--- a/examples/depth_feed_publisher/depth_feed_connection.h
+++ b/examples/depth_feed_publisher/depth_feed_connection.h
@@ -18,7 +18,7 @@ namespace liquibook { namespace examples {
   typedef std::deque<WorkingBufferPtr> WorkingBuffers;
   typedef boost::array<unsigned char, 128> Buffer;
   typedef boost::shared_ptr<Buffer> BufferPtr;
-  typedef boost::function<bool (BufferPtr, size_t)> MessageHandler;
+  typedef boost::function<bool (BufferPtr&, size_t)> MessageHandler;
   typedef boost::function<void ()> ResetHandler;
   typedef boost::function<void (const boost::system::error_code& error,
                                 std::size_t bytes_transferred)> SendHandler;

--- a/examples/depth_feed_publisher/depth_feed_subscriber.cpp
+++ b/examples/depth_feed_publisher/depth_feed_subscriber.cpp
@@ -88,7 +88,7 @@ DepthFeedSubscriber::log_depth(book::Depth<5>& depth)
   printf("----------BID----------    ----------ASK----------\n");
   while (bid || ask) {
     if (bid && bid->order_count()) {
-      printf("%8.2f %9d [%2d]", 
+      printf("%8.2f %9ld [%2d]",
              (double)bid->price() / Order::precision_,
              bid->aggregate_qty(), bid->order_count());
       if (bid == depth.last_bid_level()) {
@@ -103,7 +103,7 @@ DepthFeedSubscriber::log_depth(book::Depth<5>& depth)
     }
 
     if (ask && ask->order_count()) {
-      printf("    %8.2f %9d [%2d]\n",
+      printf("    %8.2f %9ld [%2d]\n",
              (double)ask->price() / Order::precision_,
              ask->aggregate_qty(), ask->order_count());
       if (ask == depth.last_ask_level()) {

--- a/test/unit/ut_listeners.cpp
+++ b/test/unit/ut_listeners.cpp
@@ -67,7 +67,7 @@ public:
     cancel_rejects_.push_back(order);
   }
   virtual void on_replace(const OrderPtr& order,
-                          const int32_t& , // size_delta
+                          const int64_t& , // size_delta
                           Price )          // new_price)
   {
     replaces_.push_back(order);


### PR DESCRIPTION
Fixed minor bugs to address compile errors for tests and examples. The following tools/libraries were used:

- ubuntu 22.04
- gcc 11.4
- latest quickfast master branch [f9403cf](https://github.com/objectcomputing/quickfast/commit/f9403cfb20ae5383a04772112728d233502e31c0)
- boost 1.63
- xerces 3.3
- mpc 4.1.46